### PR TITLE
Added NuxtLink for otherDownloads on downloads/client

### DIFF
--- a/app/pages/downloads/client.vue
+++ b/app/pages/downloads/client.vue
@@ -84,10 +84,12 @@
               </ul>
             </UiCardContent>
             <UiCardFooter class="border-t !pt-6 dark:border-muted/50">
-              <UiButton class="w-full py-7 text-lg">
-                <Icon :name="p.download.icon" class="mr-2 h-10 w-10 shrink-0" />
-                {{ p.download.text }}
-              </UiButton>
+              <NuxtLink class="w-full" :to="p.download.url">
+                <UiButton class="w-full py-7 text-lg">
+                  <Icon :name="p.download.icon" class="mr-2 h-10 w-10 shrink-0" />
+                  {{ p.download.text }}
+                </UiButton>
+              </NuxtLink>
             </UiCardFooter>
           </UiCard>
         </template>


### PR DESCRIPTION
The NuxtLink was missing for the other downloads option which rendered the buttons on the page useless. I added them. :smile: 